### PR TITLE
Use fallback backend when build-system present but no build-backend present on get-backend command

### DIFF
--- a/gpep517/__main__.py
+++ b/gpep517/__main__.py
@@ -36,10 +36,13 @@ def get_toml(path: Path):
 
 def get_backend(args):
     with os.fdopen(args.output_fd, "w") as out:
-        print(get_toml(args.pyproject_toml)
-              .get("build-system", {})
-              .get("build-backend", ""),
-              file=out)
+        build_system = get_toml(args.pyproject_toml).get("build-system", {})
+        if build_system:
+            build_backend = build_system.get("build-backend",
+                                             DEFAULT_FALLBACK_BACKEND)
+        else:
+            build_backend = ""
+        print(build_backend, file=out)
     return 0
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -13,7 +13,7 @@ import zipfile
 import pytest
 
 from gpep517 import __version__
-from gpep517.__main__ import main, ALL_OPT_LEVELS
+from gpep517.__main__ import main, ALL_OPT_LEVELS, DEFAULT_FALLBACK_BACKEND
 
 try:
     import distutils.sysconfig as distutils_sysconfig
@@ -114,7 +114,7 @@ def distutils_cache_cleanup():
     ["toml", "expected"],
     [("FLIT_TOML", "flit_core.buildapi"),
      ("SETUPTOOLS_TOML", "setuptools.build_meta"),
-     ("NO_BUILD_BACKEND_TOML", ""),
+     ("NO_BUILD_BACKEND_TOML", DEFAULT_FALLBACK_BACKEND),
      ("NO_BUILD_SYSTEM_TOML", ""),
      ("TEST_BACKEND_TOML", "backend"),
      (None, ""),


### PR DESCRIPTION
Fixes #8 

See also https://bugs.gentoo.org/905229 and https://gitlab.com/mkdocs-i18n/mkdocs-i18n/-/merge_requests/16